### PR TITLE
Update postgresql installation script

### DIFF
--- a/version/postgres_9_4.sh
+++ b/version/postgres_9_4.sh
@@ -6,4 +6,15 @@ echo "================= Installing Postgre 9.4 ==================="
 sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
 wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install -y postgresql-9.4
+sudo apt-get install -y postgresql-9.4 postgresql-server-dev-9.4
+
+# Fix bug https://github.com/docker/docker/issues/783
+# which prevents postgresql from staring when using aufs
+# This workaround proposed in the comment to the issue: https://github.com/docker/docker/issues/783#issuecomment-56013588
+# I've test this on my own builds
+mkdir /etc/ssl/private-copy
+mv /etc/ssl/private/* /etc/ssl/private-copy/
+rm -r /etc/ssl/private
+mv /etc/ssl/private-copy /etc/ssl/private
+chmod -R 0700 /etc/ssl/private
+chown -R postgres /etc/ssl/private


### PR DESCRIPTION
Fixes https://github.com/Shippable/support/issues/2745

I've also added installation of postgresql development libraries, which are required for building ruby gems and probably useful for other stacks too.
